### PR TITLE
Add UAParser.js

### DIFF
--- a/data.yml
+++ b/data.yml
@@ -258,6 +258,9 @@ licensors:
 - name: ServiceStack
   url: https://servicestack.net
 
+- name: UAParser.js
+  url: https://uaparser.dev/
+
 - name: University of California Santa Cruz
   url: https://ucsc.edu/
   products:


### PR DESCRIPTION
UAParser.js is released under AGPL license for open-source use and PRO licenses for proprietary use.